### PR TITLE
Faster NNPACK implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ GPU=0
 CUDNN=0
 OPENCV=1
 NNPACK=1
-ARM_NEON=0
+NNPACK_FAST=1
+ARM_NEON=1
 OPENMP=0
 DEBUG=0
 QPU_GEMM=0
@@ -30,8 +31,8 @@ OPTS=-Ofast
 LDFLAGS= -lm -pthread 
 COMMON= -Iinclude/ -Isrc/
 #CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC
-CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC -march=native -mfpmath=sse
-#CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC -mcpu=cortex-a53
+#CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC -march=native -mfpmath=sse
+CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC -mcpu=cortex-a53
 
 ifeq ($(OPENMP), 1) 
 CFLAGS+= -fopenmp
@@ -72,6 +73,11 @@ ifeq ($(NNPACK), 1)
 COMMON+= -DNNPACK
 CFLAGS+= -DNNPACK
 LDFLAGS+= -lnnpack -lpthreadpool
+endif
+
+ifeq ($(NNPACK_FAST), 1)
+COMMON+= -DNNPACK_FAST
+CFLAGS+= -DNNPACK_FAST
 endif
 
 ifeq ($(ARM_NEON), 1)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Forked from https://github.com/digitalbrain79/darknet-nnpack/
 NNPACK was used to optimize [Darknet](https://github.com/pjreddie/darknet) without using a GPU. It is useful for embedded devices using ARM CPUs.
 Idein's [qmkl](https://github.com/Idein/qmkl) is also used to accelerate the SGEMM using the GPU. This is slower than NNPACK on NEON-capable devices, and primarily useful for ARM CPUs without NEON.
 
-## Build from Raspberry Pi 3
+## Build Instructions
 Log in to Raspberry Pi using SSH.<br/>
 Install [PeachPy](https://github.com/Maratyszcza/PeachPy) and [confu](https://github.com/Maratyszcza/confu)
 ```
+sudo apt-get install python-pip
 sudo pip install --upgrade git+https://github.com/Maratyszcza/PeachPy
 sudo pip install --upgrade git+https://github.com/Maratyszcza/confu
 ```
@@ -23,10 +24,10 @@ Install clang
 ```
 sudo apt-get install clang
 ```
-Install [NNPACK-darknet](https://github.com/thomaspark-pkj/NNPACK-darknet.git)
+Install modified [NNPACK](https://github.com/shizukachan/NNPACK)
 ```
-git clone https://github.com/thomaspark-pkj/NNPACK-darknet.git
-cd NNPACK-darknet
+git clone https://github.com/shizukachan/NNPACK
+cd NNPACK
 confu setup
 ```
 If you are compiling for the Pi Zero, run `python ./configure.py --backend scalar`, otherwise run `python ./configure.py --backend auto`
@@ -81,7 +82,7 @@ YOLOv2
 Tiny-YOLO
 ./darknet detector test cfg/voc.data cfg/tiny-yolo-voc.cfg tiny-yolo-voc.weights data/person.jpg
 ```
-## NNPACK CPU-only Results (Raspberry Pi 3)
+## Original NNPACK CPU-only Results (Raspberry Pi 3)
 Model | Build Options | Prediction Time (seconds)
 :-:|:-:|:-:
 YOLOv2 | NNPACK=1,ARM_NEON=1 | 8.2
@@ -127,5 +128,19 @@ Pi Zero | Darknet | NNPACK=0,QPU_GEMM=1 | 1.32
 Pi Zero | Darknet | NNPACK=0,QPU_GEMM=0 | 14.9
 
 The QPU is slower than NNPACK-NEON. qmkl is just unable to match the performance NNPACK's extremely well tuned NEON implicit GEMM.
-I imagine the best use case for this repo would be to run neural networks on Raspberry Pi's without NEON.
+I imagine the best use case for the QPU would be to run neural networks on Raspberry Pi's without NEON.
+
+It is possible to precompute the kernel to accelerate subsequent inferences. The first inference is slower than later ones, but the speedup can be significant. This optimization requires lots of memory, so YOLOv2 won't run with this code.
+## Improved NNPACK CPU-only Results (Raspberry Pi 3)
+Model | Build Options | Prediction Time (seconds)
+:-:|:-:|:-:
+Tiny-YOLO | NNPACK=1,ARM_NEON=1,NNPACK_FAST=0 | 1.2
+Tiny-YOLO | NNPACK=1,ARM_NEON=1,NNPACK_FAST=1 | 1.5 (first frame), 0.89 (subsequent frames)
+Darknet19 | NNPACK=1,ARM_NEON=1,NNPACK_FAST=0 | 0.93
+Darknet19 | NNPACK=1,ARM_NEON=1,NNPACK_FAST=1 | 1.3 (first frame), 0.69 (subsequent frames)
+
+## GPU / config.txt considerations
+Using the QPU requires memory set aside for the GPU. Using the command `sudo vcdbg reloc` you can see how much memory is free on the GPU - it's roughly 20MB less than what is specified by gpu_mem.
+
+I recommend no less than gpu_mem=80 if you want to run Tiny-YOLO/Darknet19/Darknet. The code I've used tries to keep GPU allocations to a minimum, but if Darknet crashes before GPU memory is freed, it will be gone until a reboot.
 

--- a/include/darknet.h
+++ b/include/darknet.h
@@ -113,6 +113,17 @@ typedef struct network network;
 struct layer;
 typedef struct layer layer;
 
+#ifdef NNPACK
+struct nnpack_data
+{
+  int nnpack_initialized;
+  size_t nnpack_workspace_size;
+  void *nnpack_workspace;
+  size_t nnpack_computed_kernel_size;
+  void *nnpack_computed_kernel;
+} typedef nnpack_data;
+#endif
+
 struct layer{
     LAYER_TYPE type;
     ACTIVATION activation;
@@ -249,7 +260,7 @@ struct layer{
 
     float * m;
     float * v;
-    
+
     float * bias_m;
     float * bias_v;
     float * scale_m;
@@ -274,7 +285,7 @@ struct layer{
     float *g_cpu;
     float *o_cpu;
     float *c_cpu;
-    float *dc_cpu; 
+    float *dc_cpu;
 
     float * binary_input;
 
@@ -301,7 +312,7 @@ struct layer{
 
     struct layer *input_h_layer;
     struct layer *state_h_layer;
-	
+
     struct layer *wz;
     struct layer *uz;
     struct layer *wr;
@@ -320,7 +331,9 @@ struct layer{
     tree *softmax_tree;
 
     size_t workspace_size;
-
+#ifdef NNPACK
+    struct nnpack_data *nnpack_state;
+#endif
 #ifdef GPU
     int *indexes_gpu;
 
@@ -341,7 +354,7 @@ struct layer{
     float *g_gpu;
     float *o_gpu;
     float *c_gpu;
-    float *dc_gpu; 
+    float *dc_gpu;
 
     float *m_gpu;
     float *v_gpu;

--- a/src/convolutional_layer.c
+++ b/src/convolutional_layer.c
@@ -458,6 +458,28 @@ void forward_convolutional_layer_nnpack(convolutional_layer l, network net)
 	struct nnp_size kernel_size = { l.size, l.size };
 	struct nnp_size stride = { l.stride, l.stride };
 	int nnp_status = 0;
+#ifndef NNPACK_FAST
+	nnp_convolution_inference(
+		nnp_convolution_algorithm_implicit_gemm,
+		nnp_convolution_transform_strategy_tuple_based,
+		l.c,
+		l.n,
+		input_size,
+		input_padding,
+		kernel_size,
+		stride,
+		net.input,
+		l.weights,
+		NULL,
+		l.output,
+		NULL,
+		NULL,
+		nnp_activation_identity,
+		NULL,
+		net.threadpool,
+		NULL
+	);
+#else
 #ifdef DEBUG_NNPACK
 	printf("nnpack convolution: %dx%d, in=%d, out=%d, kernel=%d\n",l.w,l.h,l.c,l.n,l.size);
 #endif
@@ -622,6 +644,7 @@ printf("Reusing kernel of size %d at %llx\n",l.nnpack_state->nnpack_computed_ker
 #ifdef DEBUG_NNPACK
 puts("");
 #endif
+#endif /* NNPACK_FAST */
 	int out_h = convolutional_out_height(l);
 	int out_w = convolutional_out_width(l);
 	int n = out_h*out_w;

--- a/src/layer.c
+++ b/src/layer.c
@@ -12,6 +12,19 @@ void free_layer(layer l)
 #endif
         return;
     }
+#ifdef NNPACK
+    if (l.type == CONVOLUTIONAL)
+    {
+      if (l.nnpack_state)
+      {
+        if (l.nnpack_state->nnpack_workspace)
+          free(l.nnpack_state->nnpack_workspace);
+        if (l.nnpack_state->nnpack_computed_kernel)
+          free(l.nnpack_state->nnpack_computed_kernel);
+        free(l.nnpack_state);
+      }
+    }
+#endif
     if(l.cweights)           free(l.cweights);
     if(l.indexes)            free(l.indexes);
     if(l.input_layers)       free(l.input_layers);


### PR DESCRIPTION
Allow the use of memory-intensive, fast conv algorithms using Winograd/Fast Fourier transforms, leading to approximately 35% faster inference performance on the second+ inference. This does not benefit single shot inference, only repeated inferences.

Since this is a memory-time tradeoff, it is enabled as the NNPACK_FAST compile-time flag. The original behavior can be accessed by leaving NNPACK_FAST defined to 0.